### PR TITLE
Add info module, fix clean command and log command only if execution was successful

### DIFF
--- a/CobraBot/Common/EmbedFormats.cs
+++ b/CobraBot/Common/EmbedFormats.cs
@@ -47,5 +47,18 @@ namespace CobraBot.Common
                 .WithColor(Color.Blue).Build();
             return embed;
         }
+
+        /// <summary>Creates an information embed with specified information and returns it.
+        /// </summary>
+        public static Embed CreateInfoEmbed(string title, string iconUrl, EmbedFieldBuilder[] fields)
+        {
+            var embed = new EmbedBuilder()
+                .WithAuthor(new EmbedAuthorBuilder().WithName(title).WithIconUrl(iconUrl))
+                .WithFields(fields)
+                .WithColor(Color.DarkGreen)
+                .Build();
+            return embed;
+        }
+
     }
 }

--- a/CobraBot/Modules/InfoModule.cs
+++ b/CobraBot/Modules/InfoModule.cs
@@ -1,0 +1,28 @@
+﻿using System.Threading.Tasks;
+using CobraBot.Common;
+using CobraBot.Services;
+using Discord;
+using Discord.Commands;
+
+namespace CobraBot.Modules
+{
+    public class InfoModule : ModuleBase<SocketCommandContext>
+    {
+        public InfoService InfoService { get; set; }
+
+        //Sends a message with server information
+        [Command("svinfo"), Alias("info")]
+        public async Task ServerInfo()
+            => await InfoService.ServerInfoAsync(Context);
+
+        //Shows help
+        [Command("help")]
+        public async Task Help()
+            => await ReplyAsync(embed: EmbedFormats.CreateBasicEmbed("Cobra Commands", "You can check Cobra's commands [here](https://cobra.telmoduarte.me).", Color.DarkGreen));
+
+        //Shows uptime
+        [Command("uptime")]
+        public async Task Uptime()
+            => await InfoService.GetUptimeAsync(Context);
+    }
+}

--- a/CobraBot/Modules/MiscModule.cs
+++ b/CobraBot/Modules/MiscModule.cs
@@ -2,7 +2,6 @@
 using Discord;
 using System.Threading.Tasks;
 using System;
-using CobraBot.Common;
 using CobraBot.Services;
 
 namespace CobraBot.Modules
@@ -29,11 +28,6 @@ namespace CobraBot.Modules
             await Context.Client.SetGameAsync(status, url, activityType);
             Console.WriteLine($"{DateTime.Now}: Cobra's status was changed to {status} with activity type: {activityType}");
         }
-
-        //Shows help
-        [Command("help")]
-        public async Task Help()
-            => await ReplyAsync(embed: EmbedFormats.CreateBasicEmbed("Cobra Commands", "You can check Cobra's commands [here](https://cobra.telmoduarte.me).", Color.DarkGreen));
 
         //Shows discord user info
         [Command("usinfo"), Alias("whois", "user")]

--- a/CobraBot/Program.cs
+++ b/CobraBot/Program.cs
@@ -55,9 +55,10 @@ namespace CobraBot
             await Task.Delay(-1);
         }
 
-        //private Task _client_JoinedGuild(SocketGuild arg)
+        //Fired when the bot joins a new guild
+        //private Task _client_JoinedGuild(SocketGuild guild)
         //{
-        //    arg.DefaultChannel.SendMessageAsync(embed: await Helpers.Helper.CreateBasicEmbed("Hello, I'm Cobra!", "To get a list of commands, type ```"))
+        //    guild.DefaultChannel.SendMessageAsync(embed: await Helpers.Helper.CreateBasicEmbed("Hello, I'm Cobra!", "To get a list of commands, type ```"))
         //}
 
         private static ServiceProvider ConfigureServices()
@@ -88,6 +89,7 @@ namespace CobraBot
                 .AddSingleton<ModerationService>()
                 .AddSingleton<ApiService>()
                 .AddSingleton<FunService>()
+                .AddSingleton<InfoService>()
                 .AddSingleton<LoggingService>()
                 .AddSingleton<MiscService>()
                 .BuildServiceProvider();
@@ -115,7 +117,7 @@ namespace CobraBot
  | |__| (_) | |_) | | | (_| | | |_) | (_) | |_ 
   \____\___/|_.__/|_|  \__,_| |____/ \___/ \__|
                       
-                         Version {System.Reflection.Assembly.GetEntryAssembly().GetName().Version.ToString(fieldCount: 2)}
+                         Version {System.Reflection.Assembly.GetEntryAssembly()?.GetName().Version?.ToString(fieldCount: 2)}
 ");
             Console.ResetColor();
             Console.WriteLine("'" + game + "'" + " has been defined as Cobra's currently playing 'game'");

--- a/CobraBot/Services/InfoService.cs
+++ b/CobraBot/Services/InfoService.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using CobraBot.Common;
+using CobraBot.Database;
+using Discord;
+using Discord.Commands;
+using Discord.WebSocket;
+using Microsoft.EntityFrameworkCore;
+using Z.EntityFramework.Plus;
+
+namespace CobraBot.Services
+{
+    public sealed class InfoService
+    {
+        private readonly BotContext _botContext;
+
+        public InfoService(BotContext botContext)
+        {
+            _botContext = botContext;
+        }
+
+        /// <summary>Send an embed with current server information.
+        /// </summary>
+        public async Task ServerInfoAsync(SocketCommandContext context)
+        {
+            var prefix = _botContext.Guilds.AsNoTracking().Where(x => x.GuildId == context.Guild.Id)
+                             .FromCache(context.Guild.Id.ToString()).FirstOrDefault()?.CustomPrefix ?? "-";
+            var memberCount = context.Guild.MemberCount;
+            var serverId = context.Guild.Id;
+            var serverName = context.Guild.Name;
+            var serverOwner = context.Guild.Owner;
+            var serverRegion = context.Guild.VoiceRegionId;
+
+            EmbedFieldBuilder[] fields =
+            {
+                new EmbedFieldBuilder().WithName("Bot prefix:").WithValue($"`{prefix}`").WithIsInline(true),
+                new EmbedFieldBuilder().WithName("Help command:").WithValue($"`{prefix}help`").WithIsInline(true),
+                new EmbedFieldBuilder().WithName("Server name:").WithValue(serverName),
+                new EmbedFieldBuilder().WithName("Server owner:").WithValue(serverOwner).WithIsInline(true),
+                new EmbedFieldBuilder().WithName("Member count:").WithValue(memberCount).WithIsInline(true),
+                new EmbedFieldBuilder().WithName("Server ID:").WithValue(serverId),
+                new EmbedFieldBuilder().WithName("Server region:").WithValue(serverRegion).WithIsInline(true)
+            };
+
+            await context.Channel.SendMessageAsync(embed: EmbedFormats.CreateInfoEmbed($"{serverName} info", context.Guild.IconUrl, fields));
+        }
+
+        public static async Task GetUptimeAsync(SocketCommandContext context)
+        {
+            var uptime = DateTime.Now.Subtract(Process.GetCurrentProcess().StartTime);
+            var uptimeString = $"{uptime.Days} days, {uptime.Hours} hours and {uptime.Minutes} minutes";
+
+            EmbedFieldBuilder[] fields =
+            {
+                new EmbedFieldBuilder().WithName("Uptime:").WithValue(uptimeString),
+                new EmbedFieldBuilder().WithName("Dotnet version:").WithValue(Environment.Version).WithIsInline(true),
+                new EmbedFieldBuilder().WithName("Discord.NET version:")
+                    .WithValue(Assembly.GetAssembly(typeof(DiscordSocketClient))?.GetName().Version?.ToString())
+                    .WithIsInline(true),
+                new EmbedFieldBuilder().WithName("Vote:")
+                    .WithValue("[Vote here](https://top.gg/bot/389534436099883008/vote)")
+            };
+
+            await context.Channel.SendMessageAsync(embed: EmbedFormats.CreateInfoEmbed(
+                $"Cobra v{Assembly.GetEntryAssembly()?.GetName().Version?.ToString(fieldCount: 2)}",
+                context.Client.CurrentUser.GetAvatarUrl(), fields));
+        }
+    }
+}

--- a/CobraBot/Services/LoggingService.cs
+++ b/CobraBot/Services/LoggingService.cs
@@ -37,7 +37,10 @@ namespace CobraBot.Services
 
         //Create new log message according to which command was executed and on which server
         private static async Task OnCommandExecuted(Optional<CommandInfo> command, ICommandContext context, IResult result)
-            => await LogAsync(new LogMessage(LogSeverity.Info, "Command",
-            $"{context.User} has used {context.Message} on {context.Guild}."));
+        {
+            if (result.IsSuccess)
+                await LogAsync(new LogMessage(LogSeverity.Info, "Command",
+                    $"{context.User} has used {context.Message} on {context.Guild}."));
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ The project is licensed under MIT license. You can check out <a href="https://gi
 
 ## Features
 * API commands such as steam, openweathermap, oxford dictionary, covid19
-* Moderation commands, user join/leave messages and auto give role when user joins server
-* Custom prefix
+* Moderation commands and auto give role when user joins server
+* Custom prefix and user join/left messages
 * Music commands with queue, playlists support and much more
-* Misc commands such as random number generator, polls, discord user info
+* Misc commands such as random number generator, polls, discord user info, currency conversion
 * Documented code makes it easy for beginners to understand it and build their own version of the bot
 * Updated frequently
 


### PR DESCRIPTION
# Information commands
- Added info command, which displays info about the server
- Added uptime command, which displays bots uptime, dotnet version and discord.net library version
- Changed help command location from MiscModule to InfoModule
- Created new embed format for info commands

# Clean command fix
- Clean command wasn't cleaning the last message, added +1 to the count
- Added interactivity service to send and delete the "Messaged deleted" message

# Log command only if execution was successful