### PR TITLE
Add setup module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -286,3 +286,7 @@ __pycache__/
 *.btm.cs
 *.odx.cs
 *.xsd.cs
+
+CobraBot/Migrations/
+
+CobraBot/CobraDB.db

--- a/CobraBot/CobraBot.csproj
+++ b/CobraBot/CobraBot.csproj
@@ -4,12 +4,12 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
     <Authors>Telmo Duarte</Authors>
-    <Version>5.4</Version>
+    <Version>5.5</Version>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Discord.InteractivityAddon" Version="2.2.0-rc8" />
-    <PackageReference Include="Discord.Net" Version="2.3.0-dev-20201214.8" />
+    <PackageReference Include="Discord.Net" Version="2.3.0-dev-20201223.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/CobraBot/Common/EmbedFormats.cs
+++ b/CobraBot/Common/EmbedFormats.cs
@@ -50,11 +50,12 @@ namespace CobraBot.Common
 
         /// <summary>Creates an information embed with specified information and returns it.
         /// </summary>
-        public static Embed CreateInfoEmbed(string title, EmbedFooterBuilder footer, string iconUrl, EmbedFieldBuilder[] fields)
+        public static Embed CreateInfoEmbed(string title, string description, EmbedFooterBuilder footer, string iconUrl, EmbedFieldBuilder[] fields)
         {
             var embed = new EmbedBuilder()
                 .WithAuthor(new EmbedAuthorBuilder().WithName(title).WithIconUrl(iconUrl))
                 .WithFields(fields)
+                .WithDescription(description)
                 .WithColor(Color.DarkGreen)
                 .WithFooter(footer)
                 .Build();

--- a/CobraBot/Database/BotContext.cs
+++ b/CobraBot/Database/BotContext.cs
@@ -39,11 +39,12 @@ namespace CobraBot.Database
 
         public void SaveChangesAndExpire(string tag)
         {
-            QueryCacheManager.ExpireTag(tag);
             SaveChanges();
+            QueryCacheManager.ExpireTag(tag);
         }
 
-        
+        /// <summary>Returns guild settings for specified guildId. If specified guild doesn't have a database entry, then creates one.
+        /// </summary>
         public async Task <Guild> GetGuildSettings(ulong guildId)
         {
             var guild = Guilds.FirstOrDefault(x => x.GuildId == guildId);
@@ -53,6 +54,14 @@ namespace CobraBot.Database
             var addedGuild = await Guilds.AddAsync(new Guild{GuildId = guildId});
             await SaveChangesAndExpireAsync(guildId.ToString());
             return addedGuild.Entity;
+        }
+
+        /// <summary>Gets guild prefix for specified guildId. If guild doesn't have a custom prefix, returns the default prefix: '-'
+        /// </summary>
+        public string GetGuildPrefix(ulong guildId)
+        {
+            return Guilds.AsNoTracking().Where(x => x.GuildId == guildId)
+                .FromCache(guildId.ToString()).FirstOrDefault()?.CustomPrefix ?? "-";
         }
     }
 }

--- a/CobraBot/Database/Models/Guild.cs
+++ b/CobraBot/Database/Models/Guild.cs
@@ -8,7 +8,8 @@ namespace CobraBot.Database.Models
         public int Id { get; set; }
         
         public ulong GuildId { get; set; }
-        public ulong JoinLeaveChannel { get; set; }
+        public ulong WelcomeChannel { get; set; }
+        public ulong ModerationChannel { get; set; }
         public string CustomPrefix { get; set; }
         public string RoleOnJoin { get; set; }
     }

--- a/CobraBot/Helpers/Helper.cs
+++ b/CobraBot/Helpers/Helper.cs
@@ -2,8 +2,7 @@ using Discord;
 using Discord.Commands;
 using Newtonsoft.Json;
 using System;
-using System.IO;
-using System.Net;
+using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Discord.WebSocket;
@@ -30,13 +29,7 @@ namespace CobraBot.Helpers
         /// </summary>
         public static IRole DoesRoleExist(IGuild guild, string roleName)
         {
-            foreach (var role in guild.Roles)
-            {
-                if (role.Name.Equals(roleName, StringComparison.OrdinalIgnoreCase))
-                    return role;
-            }
-
-            return null;
+            return guild.Roles.FirstOrDefault(role => role.Name.Contains(roleName));
         }
 
         /// <summary>Checks if specified string contains digits only.
@@ -83,8 +76,13 @@ namespace CobraBot.Helpers
 
             try
             {
+                //Try to send the request
                 var response = await Client.SendAsync(request);
+
+                //Make sure the request was successful
                 response.EnsureSuccessStatusCode();
+
+                //Save the request response to responseBody
                 responseBody = await response.Content.ReadAsStringAsync();
             }
             catch (Exception e)

--- a/CobraBot/Modules/BotOwnerModule.cs
+++ b/CobraBot/Modules/BotOwnerModule.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Threading.Tasks;
+using Discord;
+using Discord.Commands;
+
+namespace CobraBot.Modules
+{
+    [RequireOwner]
+    [Name("Owner")]
+    public class BotOwnerModule : ModuleBase<SocketCommandContext>
+    {
+        //Defines bot's status
+        [Command("setbotgame")]
+        public async Task SetGame(string status, string activity = null, string url = null)
+        {
+            var activityType = activity switch
+            {
+                "streaming" => ActivityType.Streaming,
+                "playing" => ActivityType.Playing,
+                "listening" => ActivityType.Listening,
+                "watching" => ActivityType.Watching,
+                "custom" => ActivityType.CustomStatus,
+                _ => ActivityType.Playing
+            };
+
+            await Context.Client.SetGameAsync(status, url, activityType);
+            Console.WriteLine($"{DateTime.Now}: Cobra's status was changed to {status} with activity type: {activityType}");
+        }
+
+        //Downloads users from every guild to cache
+        [Command("downloadusers")]
+        public async Task DownloadUsers()
+        {
+            await Context.Client.DownloadUsersAsync(Context.Client.Guilds);
+        }
+    }
+}

--- a/CobraBot/Modules/MiscModule.cs
+++ b/CobraBot/Modules/MiscModule.cs
@@ -1,7 +1,5 @@
 ﻿using Discord.Commands;
-using Discord;
 using System.Threading.Tasks;
-using System;
 using CobraBot.Services;
 
 namespace CobraBot.Modules
@@ -11,25 +9,6 @@ namespace CobraBot.Modules
     public class MiscModule : ModuleBase<SocketCommandContext>
     {
         public MiscService MiscService { get; set; }
-
-        //Defines bot's status
-        [RequireOwner]
-        [Command("setbotgame")]
-        public async Task SetGame(string status, string activity = null, string url = null)
-        {
-            var activityType = activity switch
-            {
-                "streaming" => ActivityType.Streaming,
-                "playing" => ActivityType.Playing,
-                "listening" => ActivityType.Listening,
-                "watching" => ActivityType.Watching,
-                "custom" => ActivityType.CustomStatus,
-                _ => ActivityType.Playing
-            };
-
-            await Context.Client.SetGameAsync(status, url, activityType);
-            Console.WriteLine($"{DateTime.Now}: Cobra's status was changed to {status} with activity type: {activityType}");
-        }
 
         //Converts specified value from one currency to another
         [Command("convert"), Alias("conversion", "conv")]

--- a/CobraBot/Modules/ModerationModule.cs
+++ b/CobraBot/Modules/ModerationModule.cs
@@ -79,42 +79,11 @@ namespace CobraBot.Modules
             => await ReplyAsync(embed: await ModerationService.UpdateRoleAsync(user, operation, roleName));
 
 
-        [RequireUserPermission(GuildPermission.Administrator)]
-        [Command("prefix")]
-        [Name("Prefix"), Summary("Changes bot prefix for current server.")]
-        public async Task SetPrefix(string prefix)
-            => await ReplyAsync(embed: await ModerationService.ChangePrefixAsync(prefix, Context));
-
-
-        #region Welcome channel and Role on join
-        //Set welcome channel
-        [RequireUserPermission(GuildPermission.Administrator)]
-        [Command("setwelcome")]
-        [Name("Set welcome channel"), Summary("Sets channel where join/left messages are shown.")]
-        public async Task SetWelcomeChannel(ITextChannel textChannel)
-            => await ReplyAsync(embed: await ModerationService.SetWelcomeChannel(textChannel));
-
-        //Reset welcome channel
-        [RequireUserPermission(GuildPermission.Administrator)]
-        [Command("resetwelcome")]
-        [Name("Reset welcome channel"), Summary("Resets channel where join/left messages are shown.")]
-        public async Task ResetWelcomeChannel()
-            => await ReplyAsync(embed: await ModerationService.ResetWelcomeChannel(Context));
-
-
-        //Set role on join
-        [RequireUserPermission(GuildPermission.Administrator)]
-        [Command("setroleonjoin")]
-        [Name("Set role on join"), Summary("Sets default role that users receive when they join the server.")]
-        public async Task SetRoleOnJoin(string roleName)
-            => await ReplyAsync(embed: await ModerationService.SetRoleOnJoin(Context.Guild, roleName));
-
-        //Reset role on join
-        [RequireUserPermission(GuildPermission.Administrator)]
-        [Command("resetroleonjoin")]
-        [Name("Reset role on join"), Summary("Resets role that users receive when they join the server.")]
-        public async Task ResetRoleOnJoin()
-            => await ReplyAsync(embed: await ModerationService.ResetRoleOnJoin(Context));
-#endregion
+        [RequireBotPermission(GuildPermission.ManageChannels)]
+        [RequireUserPermission(GuildPermission.ManageChannels)]
+        [Command("slowmode")]
+        [Name("Slowmode"), Summary("Sets specified channel slowmode to specified interval")]
+        public async Task Slowmode(ITextChannel channel, int interval = 0)
+            => await ModerationService.SlowmodeAsync(channel, interval, Context);
     }
 }

--- a/CobraBot/Modules/MusicModule.cs
+++ b/CobraBot/Modules/MusicModule.cs
@@ -63,7 +63,7 @@ namespace CobraBot.Modules
 
         [Command("seek")]
         [Name("Seek"), Summary("Seeks current track to specified position.")]
-        public async Task Seek(TimeSpan positionToSeek)
+        public async Task Seek(string positionToSeek)
             => await MusicService.SeekTrackAsync(Context, positionToSeek);
         
         [Command("search")]

--- a/CobraBot/Modules/SetupModule.cs
+++ b/CobraBot/Modules/SetupModule.cs
@@ -1,0 +1,51 @@
+﻿using System.Threading.Tasks;
+using CobraBot.Services;
+using Discord;
+using Discord.Commands;
+
+namespace CobraBot.Modules
+{
+    [RequireContext(ContextType.Guild)]
+    [RequireUserPermission(GuildPermission.Administrator)]
+    [Name("Setup Module")]
+    public class SetupModule : ModuleBase<SocketCommandContext>
+    {
+        public SetupService SetupService { get; set; }
+
+        [Command("setup")]
+        [Name("Setup"), Summary("Starts bot setup process.")]
+        public async Task Setup()
+            => await SetupService.SetupAsync(Context);
+
+        #region Prefix, Welcome Channel, Role on Join, Moderation Channel
+        [Command("prefix")]
+        [Name("Prefix"), Summary("Changes bot prefix for current server.")]
+        public async Task SetPrefix(string prefix)
+            => await ReplyAsync(embed: await SetupService.ChangePrefixAsync(prefix, Context));
+
+        //Set welcome channel
+        [Command("setwelcome")]
+        [Name("Set welcome channel"), Summary("Sets channel where join/left messages are shown.")]
+        public async Task SetWelcomeChannel(ITextChannel textChannel)
+            => await ReplyAsync(embed: await SetupService.SetWelcomeChannel(textChannel));
+
+        //Reset welcome channel
+        [Command("resetwelcome")]
+        [Name("Reset welcome channel"), Summary("Resets channel where join/left messages are shown.")]
+        public async Task ResetWelcomeChannel()
+            => await ReplyAsync(embed: await SetupService.ResetWelcomeChannel(Context));
+
+        //Set role on join
+        [Command("setroleonjoin")]
+        [Name("Set role on join"), Summary("Sets default role that users receive when they join the server.")]
+        public async Task SetRoleOnJoin(string roleName)
+            => await ReplyAsync(embed: await SetupService.SetRoleOnJoin(Context.Guild, roleName));
+
+        //Reset role on join
+        [Command("resetroleonjoin")]
+        [Name("Reset role on join"), Summary("Resets role that users receive when they join the server.")]
+        public async Task ResetRoleOnJoin()
+            => await ReplyAsync(embed: await SetupService.ResetRoleOnJoin(Context));
+        #endregion
+    }
+}

--- a/CobraBot/Services/InfoService.cs
+++ b/CobraBot/Services/InfoService.cs
@@ -59,7 +59,7 @@ namespace CobraBot.Services
             };
 
             await context.Channel.SendMessageAsync(
-                embed: EmbedFormats.CreateInfoEmbed($"{serverName} info",
+                embed: EmbedFormats.CreateInfoEmbed($"{serverName} info", context.Guild.Description,
                     new EmbedFooterBuilder().WithIconUrl(context.User.GetAvatarUrl())
                         .WithText($"Requested by: {context.User}"), context.Guild.IconUrl, fields));
         }
@@ -246,7 +246,7 @@ namespace CobraBot.Services
             };
             
             await context.Channel.SendMessageAsync(embed: EmbedFormats.CreateInfoEmbed(
-                $"Cobra v{Assembly.GetEntryAssembly()?.GetName().Version?.ToString(2)}",
+                $"Cobra v{Assembly.GetEntryAssembly()?.GetName().Version?.ToString(2)}","",
                 new EmbedFooterBuilder().WithText("Developed by Matcher#0183"), context.Client.CurrentUser.GetAvatarUrl(), fields));
         }
     }

--- a/CobraBot/Services/LoggingService.cs
+++ b/CobraBot/Services/LoggingService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
+using CobraBot.Common;
 using Discord;
 using Discord.Commands;
 using Discord.WebSocket;
@@ -16,12 +17,9 @@ namespace CobraBot.Services
             client.Log += LogAsync;
             commandService.Log += LogAsync;
             lavaNode.OnLog += LogAsync;
-            
-            //Command executed fires when a command is executed
-            commandService.CommandExecuted += OnCommandExecuted;
         }
 
-        private static Task LogAsync(LogMessage message)
+        public static Task LogAsync(LogMessage message)
         {
             if (message.Exception is CommandException cmdException)
             {
@@ -33,14 +31,6 @@ namespace CobraBot.Services
                 Console.WriteLine($"[General/{message.Severity}] {DateTime.Now:d} {message}");
 
             return Task.CompletedTask;
-        }
-
-        //Create new log message according to which command was executed and on which server
-        private static async Task OnCommandExecuted(Optional<CommandInfo> command, ICommandContext context, IResult result)
-        {
-            if (result.IsSuccess)
-                await LogAsync(new LogMessage(LogSeverity.Info, "Command",
-                    $"{context.User} has used {context.Message} on {context.Guild}."));
         }
     }
 }

--- a/CobraBot/Services/SetupService.cs
+++ b/CobraBot/Services/SetupService.cs
@@ -1,0 +1,293 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using CobraBot.Common;
+using CobraBot.Database;
+using CobraBot.Helpers;
+using Discord;
+using Discord.Commands;
+using Interactivity;
+using Interactivity.Selection;
+
+namespace CobraBot.Services
+{
+    public sealed class SetupService
+    {
+        private readonly InteractivityService _interactivityService;
+        private readonly BotContext _botContext;
+
+        public SetupService(InteractivityService interactivityService, BotContext botContext)
+        {
+            _interactivityService = interactivityService;
+            _botContext = botContext;
+        }
+
+        /// <summary>Starts setup process where guild admins can easily setup their specific guild settings.
+        /// </summary>
+        public async Task SetupAsync(SocketCommandContext context)
+        {
+            await context.Message.DeleteAsync();
+
+            //Selection builder used to know which settings the admin wants to change
+            var selection = new ReactionSelectionBuilder<string>()
+                .WithTitle("Cobra Setup")
+                .WithValues("Welcome Channel", "Role on Join", "Custom Prefix", "Moderation Channel")
+                .WithEmotes(new Emoji("1️⃣"), new Emoji("2️⃣"), new Emoji("3️⃣"), new Emoji("4️⃣"))
+                .WithUsers(context.User)
+                .WithAllowCancel(true)
+                .WithDeletion(DeletionOptions.AfterCapturedContext | DeletionOptions.Invalids);
+
+            //Send the selection builder and save the result
+            var result = await _interactivityService.SendSelectionAsync(selection.Build(), context.Channel, TimeSpan.FromMinutes(3));
+
+            //We switch through every result
+            switch (result.Value)
+            {
+                //If user wants to setup Welcome Channel
+                case "Welcome Channel":
+
+                    await context.Channel.SendMessageAsync(
+                        "Please mention the #textChannel you want to setup as the Welcome Channel:");
+                    
+                    var welcomeResult = await _interactivityService.NextMessageAsync(x => x.Author == context.User);
+
+                    if (welcomeResult.IsSuccess)
+                    {
+                        var textChannel = (ITextChannel)welcomeResult.Value.MentionedChannels.FirstOrDefault();
+
+                        if (textChannel == null)
+                        {
+                            await context.Channel.SendMessageAsync(
+                                embed: EmbedFormats.CreateErrorEmbed("**No channel specified!** Please try again."));
+                            return;
+                        }
+
+                        var guildSettings = await _botContext.GetGuildSettings(context.Guild.Id);
+
+                        guildSettings.WelcomeChannel = textChannel.Id;
+                        await _botContext.SaveChangesAndExpireAsync(context.Guild.Id.ToString());
+                        await context.Channel.SendMessageAsync(embed: EmbedFormats.CreateBasicEmbed(
+                            "Welcome channel changed", $"Welcome channel is now {textChannel.Mention}",
+                            Color.DarkGreen));
+                    }
+                    else
+                    {
+                        await context.Channel.SendMessageAsync(
+                            embed: EmbedFormats.CreateErrorEmbed("**An error occurred!** Please try again."));
+                    }
+                    break;
+
+                //If user wants to setup Role on Join
+                case "Role on Join":
+
+                    await context.Channel.SendMessageAsync(
+                        "Please type the name of the role you want to setup as the role on join:");
+                    var roleResult = await _interactivityService.NextMessageAsync(x => x.Author == context.User);
+
+                    if (roleResult.IsSuccess)
+                    {
+                        var role = Helper.DoesRoleExist(context.Guild, roleResult.Value.Content);
+
+                        if (role == null)
+                        {
+                            await context.Channel.SendMessageAsync(
+                                embed: EmbedFormats.CreateErrorEmbed("**Role doesn't exist!** Please try again."));
+                            return;
+                        }
+
+                        var guildSettings = await _botContext.GetGuildSettings(context.Guild.Id);
+
+                        guildSettings.RoleOnJoin = role.Name;
+                        await _botContext.SaveChangesAndExpireAsync(context.Guild.Id.ToString());
+                        await context.Channel.SendMessageAsync(embed: EmbedFormats.CreateBasicEmbed(
+                            "Role on join changed", $"Role on join was set to **{role.Name}**",
+                            Color.DarkGreen));
+                    }
+                    else
+                    {
+                        await context.Channel.SendMessageAsync(
+                            embed: EmbedFormats.CreateErrorEmbed("**An error occurred!** Please try again."));
+                    }
+                    break;
+
+                //If user wants to setup Custom Prefix
+                case "Custom Prefix":
+
+                    await context.Channel.SendMessageAsync(
+                        "Please type the new prefix for your guild (type `default` to reset it):");
+                    var prefixResult = await _interactivityService.NextMessageAsync(x => x.Author == context.User);
+
+                    if (prefixResult.IsSuccess)
+                    {
+                        var guildSettings = await _botContext.GetGuildSettings(context.Guild.Id);
+
+                        var newPrefix = prefixResult.Value.Content;
+
+                        //If newPrefix == default, it means the user wants to reset the prefix
+                        if (newPrefix.ToLower() == "default")
+                        {
+                            //We check if the current prefix is already the default one (null)
+                            string currentPrefix = guildSettings.CustomPrefix;
+                            if (currentPrefix == null)
+                            {
+                                await context.Channel.SendMessageAsync(
+                                    embed: EmbedFormats.CreateErrorEmbed("Bot prefix is already the default one!"));
+                                return;
+                            }
+
+                            //If the current prefix isn't the default, then set it to null (default)
+                            guildSettings.CustomPrefix = null;
+                            await _botContext.SaveChangesAndExpireAsync(context.Guild.Id.ToString());
+                            await context.Channel.SendMessageAsync(
+                                embed: EmbedFormats.CreateBasicEmbed("Custom prefix Changed", "Bot prefix was reset to **-**",
+                                    Color.DarkGreen));
+                            return;
+                        }
+
+                        //If the newPrefix is larger than 5 characters, return
+                        if (newPrefix.Length > 5)
+                        {
+                            await context.Channel.SendMessageAsync(
+                                embed: EmbedFormats.CreateErrorEmbed("Bot prefix can't be longer than 5 characters!"));
+                            return;
+                        }
+
+                        //If all checks pass, set the newPrefix as the guilds custom prefix
+                        guildSettings.CustomPrefix = newPrefix;
+                        await _botContext.SaveChangesAndExpireAsync(context.Guild.Id.ToString());
+                        await context.Channel.SendMessageAsync(embed: EmbedFormats.CreateBasicEmbed(
+                            "Custom prefix Changed", $"Cobra's prefix is now:  **{newPrefix}**", Color.DarkGreen));
+                    }
+                    else
+                    {
+                        await context.Channel.SendMessageAsync(
+                            embed: EmbedFormats.CreateErrorEmbed("**An error occurred!** Please try again."));
+                    }
+                    break;
+
+                //If user wants to setup Moderation Channel
+                case "Moderation Channel":
+                    await context.Channel.SendMessageAsync(
+                        "Please mention the #textChannel you want to setup as the Moderation Channel:");
+
+                    var moderationResult = await _interactivityService.NextMessageAsync(x => x.Author == context.User);
+
+                    if (moderationResult.IsSuccess)
+                    {
+                        var textChannel = (ITextChannel)moderationResult.Value.MentionedChannels.FirstOrDefault();
+
+                        if (textChannel == null)
+                        {
+                            await context.Channel.SendMessageAsync(
+                                embed: EmbedFormats.CreateErrorEmbed("**No channel specified!** Please try again."));
+                            return;
+                        }
+
+                        var guildSettings = await _botContext.GetGuildSettings(context.Guild.Id);
+
+                        guildSettings.ModerationChannel = textChannel.Id;
+                        await _botContext.SaveChangesAndExpireAsync(context.Guild.Id.ToString());
+                        await context.Channel.SendMessageAsync(embed: EmbedFormats.CreateBasicEmbed(
+                            "Moderation channel changed", $"Welcome channel is now {textChannel.Mention}",
+                            Color.DarkGreen));
+                    }
+                    else
+                    {
+                        await context.Channel.SendMessageAsync(
+                            embed: EmbedFormats.CreateErrorEmbed("**An error occurred!** Please try again."));
+                    }
+                    break;
+            }
+        }
+
+        /// <summary>Changes guild's bot prefix.
+        /// </summary>
+        public async Task<Embed> ChangePrefixAsync(string prefix, SocketCommandContext context)
+        {
+            var guildSettings = await _botContext.GetGuildSettings(context.Guild.Id);
+
+            //If user input == default
+            if (prefix == "default")
+            {
+                //Check if the guild has custom prefix
+                string currentPrefix = guildSettings.CustomPrefix;
+
+                //If the guild doesn't have custom prefix, return
+                if (currentPrefix == null)
+                    return EmbedFormats.CreateErrorEmbed("Bot prefix is already the default one!");
+
+
+                //If they have a custom prefix, set it to null
+                guildSettings.CustomPrefix = null;
+                await _botContext.SaveChangesAndExpireAsync(context.Guild.Id.ToString());
+                return EmbedFormats.CreateBasicEmbed("", "Bot prefix was reset to:  **-**", Color.DarkGreen);
+            }
+
+            //If user input is longer than 5, return
+            if (prefix.Length > 5)
+                return EmbedFormats.CreateErrorEmbed("Bot prefix can't be longer than 5 characters!");
+
+            //If every check passes, we add the new custom prefix to the database
+            guildSettings.CustomPrefix = prefix;
+            await _botContext.SaveChangesAndExpireAsync(context.Guild.Id.ToString());
+
+            return EmbedFormats.CreateBasicEmbed("Custom prefix Changed", $"Cobra's prefix is now:  **{prefix}**", Color.DarkGreen);
+        }
+
+        /// <summary>Sets guild's welcome channel.
+        /// </summary>
+        public async Task<Embed> SetWelcomeChannel(ITextChannel textChannel)
+        {
+            var guildSettings = await _botContext.GetGuildSettings(textChannel.Guild.Id);
+
+            guildSettings.WelcomeChannel = textChannel.Id;
+            await _botContext.SaveChangesAndExpireAsync(textChannel.Guild.Id.ToString());
+
+            return EmbedFormats.CreateBasicEmbed("Welcome channel changed", $"Welcome channel is now {textChannel.Mention}", Color.DarkGreen);
+        }
+
+        /// <summary>Resets guild's welcome channel.
+        /// </summary>
+        public async Task<Embed> ResetWelcomeChannel(SocketCommandContext context)
+        {
+            var guildSettings = await _botContext.GetGuildSettings(context.Guild.Id);
+
+            guildSettings.WelcomeChannel = 0;
+            await _botContext.SaveChangesAndExpireAsync(context.Guild.Id.ToString());
+
+            return EmbedFormats.CreateBasicEmbed("Welcome channel changed",
+                "Welcome channel was reset.\nYour server doesn't have a welcome channel setup right now.",
+                Color.DarkMagenta);
+        }
+
+        /// <summary>Changes role that users receive when they join the server.
+        /// </summary>
+        public async Task<Embed> SetRoleOnJoin(IGuild guild, string roleName)
+        {
+            var role = Helper.DoesRoleExist(guild, roleName);
+
+            if (role == null)
+                return EmbedFormats.CreateErrorEmbed($"Role **{roleName}** doesn't exist!");
+
+            var guildSettings = await _botContext.GetGuildSettings(guild.Id);
+
+            guildSettings.RoleOnJoin = role.Name;
+            await _botContext.SaveChangesAndExpireAsync(guild.Id.ToString());
+
+            return EmbedFormats.CreateBasicEmbed("Role on join changed", $"Role on join was set to **{role.Name}**", Color.DarkGreen);
+        }
+
+        /// <summary>Changes role that users receive when they join the server.
+        /// </summary>
+        public async Task<Embed> ResetRoleOnJoin(SocketCommandContext context)
+        {
+            var guildSettings = await _botContext.GetGuildSettings(context.Guild.Id);
+
+            guildSettings.RoleOnJoin = null;
+            await _botContext.SaveChangesAndExpireAsync(context.Guild.Id.ToString());
+
+            return EmbedFormats.CreateBasicEmbed("Role on join changed",
+                "Role on join was reset.\nYour server doesn't have a role on join setup right now.", Color.DarkMagenta);
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <img align="right" width="100" height="100" src="https://i.imgur.com/0fFn8H0.png">
 
 ### A Discord Bot built with: 
-* [Discord.NET (2.3.0-dev-20201214.8)](https://github.com/RogueException/Discord.Net) - .NET Discord API Wrapper.
+* [Discord.NET (2.3.0-dev-20201223.7)](https://github.com/RogueException/Discord.Net) - .NET Discord API Wrapper.
 * [Discord Interactivity Addon (2.2.0-rc8)](https://github.com/Playwo/Discord.InteractivityAddon) - Discord.NET interactivity addon
 * [.NET 5](https://docs.microsoft.com/en-us/dotnet/core/dotnet-five) - Framework used.
 * [Victoria (v5.1.11)](https://github.com/Yucked/Victoria) - .NET Lavalink wrapper.


### PR DESCRIPTION
# Setup Module
- Added setup module, it has every command used to setup guild specific settings for the bot such as custom prefix, etc
- Created setup command, its an easy way for guild admins to setup guild specific settings
- Added Moderation channel entry in Guild database model

# Added bot owner commands

# Refactored CommandHandler

# Added slowmode command to moderation module

# Fixed music module's seek command