### PR TITLE
Added OnTrackStarted event

### DIFF
--- a/CobraBot/CobraBot.csproj
+++ b/CobraBot/CobraBot.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
     <Authors>Telmo Duarte</Authors>
-    <Version>5.6</Version>
+    <Version>5.7</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CobraBot/Common/EmbedFormats.cs
+++ b/CobraBot/Common/EmbedFormats.cs
@@ -38,26 +38,20 @@ namespace CobraBot.Common
             return embed;
         }
 
-        /// <summary>Creates an embed with specified information and returns it.
+        /// <summary>Creates a now playing embed for specified LavaTrack and returns the embed.
         /// </summary>
-        public static Embed CreateMusicEmbed(string title, string description, string thumbnailUrl)
-        {
-            var embed = new EmbedBuilder()
-                .WithTitle(title)
-                .WithDescription(description)
-                .WithThumbnailUrl(thumbnailUrl)
-                .WithColor(Color.Blue).Build();
-            return embed;
-        }
-
-        public static async Task<Embed> NowPlayingEmbed(LavaTrack track)
+        public static async Task<Embed> NowPlayingEmbed(LavaTrack track, bool withDuration = false)
         {
             var embed = new EmbedBuilder()
                 .WithTitle("Now playing :cd:")
                 .WithDescription($"[{track.Title}]({track.Url})")
                 .WithThumbnailUrl(await track.FetchArtworkAsync())
-                .WithColor(Color.Blue).Build();
-            return embed;
+                .WithColor(Color.Blue);
+
+            if (withDuration)
+                embed.WithDescription($"[{track.Title}]({track.Url})\n({track.Position:hh\\:mm\\:ss}/{track.Duration})");
+
+            return embed.Build();
         }
 
         /// <summary>Creates an information embed with specified information and returns it.

--- a/CobraBot/Handlers/CommandHandler.cs
+++ b/CobraBot/Handlers/CommandHandler.cs
@@ -31,12 +31,11 @@ namespace CobraBot.Handlers
             _commands.CommandExecuted += OnCommandExecuted;
         }
 
+
+        //Adds modules and services
         public async Task InitializeAsync()
-        {
-            await _commands.AddModulesAsync(
-                assembly: Assembly.GetEntryAssembly(),
-                services: _services);
-        }
+            => await _commands.AddModulesAsync(Assembly.GetEntryAssembly(), _services);
+
 
         //Called whenever a user sends a message
         private async Task HandleCommandAsync(SocketMessage rawMessage)

--- a/CobraBot/Modules/MusicModule.cs
+++ b/CobraBot/Modules/MusicModule.cs
@@ -19,12 +19,7 @@ namespace CobraBot.Modules
         [Command("leave")]
         [Name("Leave"), Summary("Makes bot leave voice channel.")]
         public async Task Leave()
-            => await MusicService.LeaveAsync(Context);                   
-
-        [Command("lyrics")]
-        [Name("Lyrics"), Summary("Displays lyrics for current song.")]
-        public async Task FetchLyrics()
-            => await ReplyAsync(embed: await MusicService.FetchLyricsAsync(Context.Guild));
+            => await MusicService.LeaveAsync(Context);
 
         [Command("play"), Alias("p")]
         [Name("Play"), Summary("Plays specified song.")]
@@ -40,6 +35,12 @@ namespace CobraBot.Modules
         [Name("Queue"), Summary("Shows songs queue.")]
         public async Task Queue()
             => await MusicService.QueueAsync(Context);
+
+        [Command("lyrics")]
+        [Name("Lyrics"), Summary("Displays lyrics for current song.")]
+        public async Task FetchLyrics()
+            => await ReplyAsync(embed: await MusicService.FetchLyricsAsync(Context.Guild));
+
 
         [Command("nowplaying"), Alias("np")]
         [Name("Now playing"), Summary("Shows currently playing song.")]

--- a/CobraBot/Services/InfoService.cs
+++ b/CobraBot/Services/InfoService.cs
@@ -116,7 +116,7 @@ namespace CobraBot.Services
                 .WithColor(Color.DarkGreen)
                 .WithAuthor(new EmbedAuthorBuilder().WithIconUrl(context.Guild.IconUrl)
                     .WithName($"Commands you have access to on {context.Guild.Name}"))
-                .WithDescription($"For help with a specific command type  `{prefix}help [command]`")
+                .WithDescription($"The prefix for commands is `{prefix}`\nFor help with a specific command type  `{prefix}help [command]`")
                 .WithFooter(x =>
                 {
                     x.Text = "Cobra | cobra.telmoduarte.me";
@@ -136,22 +136,24 @@ namespace CobraBot.Services
                     //If the user does have permission, then continue
                     if (!result.IsSuccess) continue;
 
-                    //Append command parameters if the command has them
-                    if (command.Parameters.Any())
-                    {
-                        //Append the command to the description string builder
-                        description.Append($"`{prefix}{command.Aliases[0]} ");
-                        //Append command parameters if the command has them
-                        description.Append($"[{string.Join(", ", command.Parameters.Select(p => p.Name))}]`");
-                    }
-                    else
-                    {
-                        //Append the command to the description string builder
-                        description.Append($"`{prefix}{command.Aliases[0]}`");
-                    }
-                   
+                    ////Append command parameters if the command has them
+                    //if (command.Parameters.Any())
+                    //{
+                    //    //Append the command to the description string builder
+                    //    description.Append($"`{command.Aliases[0]}`");
+                    //    //Append command parameters if the command has them
+                    //    description.Append($"[{string.Join(", ", command.Parameters.Select(p => p.Name))}]`");
+                    //}
+                    //else
+                    //{
+                    //    //Append the command to the description string builder
+                    //    description.Append($"`{command.Aliases[0]}`");
+                    //}
+                    
+                    description.Append($"`{command.Aliases[0]}`");
+
                     //Append new line so commands don't get mixed up in one line
-                    description.Append('\n');
+                    description.Append(' ');
                 }
                 
                 //If description isn't null or white space
@@ -186,8 +188,7 @@ namespace CobraBot.Services
         {
             //Get guilds custom prefix.
             //Sets prefix to - if the guild doesn't have a custom prefix
-            var prefix = _botContext.Guilds.AsNoTracking().Where(x => x.GuildId == context.Guild.Id)
-                .FromCache(context.Guild.Id.ToString()).FirstOrDefault()?.CustomPrefix ?? "-";
+            var prefix = _botContext.GetGuildPrefix(context.Guild.Id);
             
             //Search for commands equal to commandName
             var searchResult = _commandService.Search(context, commandName);
@@ -206,7 +207,7 @@ namespace CobraBot.Services
             //Get the command info and command parameters
             var cmd = commandMatch.Command;
             var param = cmd.Parameters.Select(x => x.Name);
-
+            
             //Send message on how to use the command
             var helpEmbed = new EmbedBuilder()
                 .WithColor(Color.DarkGreen)
@@ -218,6 +219,7 @@ namespace CobraBot.Services
 
             await context.Channel.SendMessageAsync(embed: helpEmbed.Build());
         }
+
 
         /// <summary>Send an embed with the bot uptime.
         /// </summary>


### PR DESCRIPTION
- Now playing messages are now sent when OnTrackStarted is called, this prevents the bot sending Now playing messages before checking for exceptions on music playback.
- Added regex expression on TrackExceptionEvent error message because for some reason Lavalink returns the error message with \n's