### PR TITLE
Release version 6.6

### DIFF
--- a/CobraBot/CobraBot.csproj
+++ b/CobraBot/CobraBot.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
     <Authors>Telmo Duarte</Authors>
-    <Version>6.5</Version>
+    <Version>6.6</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CobraBot/Common/Extensions/ExtensionMethods.cs
+++ b/CobraBot/Common/Extensions/ExtensionMethods.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Threading.Tasks;
+using CobraBot.Preconditions;
+using Discord.Commands;
+
+namespace CobraBot.Common.Extensions
+{
+    public static class ExtensionMethods
+    {
+        public static async Task<bool> HasPermissionToExecute(this CommandInfo command, ICommandContext context, IServiceProvider services)
+        {
+            foreach (var precondition in command.Preconditions)
+            {
+                if (precondition is Ratelimit)
+                    continue;
+
+                var canExecute = await precondition.CheckPermissionsAsync(context, command, services);
+
+                if (!canExecute.IsSuccess)
+                    return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/CobraBot/Modules/InfoModule.cs
+++ b/CobraBot/Modules/InfoModule.cs
@@ -34,8 +34,8 @@ namespace CobraBot.Modules
 
 
         //Shows help
-        [Command("help")]
-        [Name("Help"), Summary("Shows information about a command.")]
+        [Command("chelp")]
+        [Name("Command Help"), Summary("Shows information about a command.")]
         public async Task Help([Remainder] string command)
             => await InfoService.HelpAsync(Context, command);
 

--- a/CobraBot/Modules/UtilitiesModule.cs
+++ b/CobraBot/Modules/UtilitiesModule.cs
@@ -20,7 +20,7 @@ namespace CobraBot.Modules
 
         //Poll command
         [Command("poll"), Ratelimit(1, 1, Measure.Seconds)]
-        [Name("Poll"), Summary("Creates a poll with specified question and choices.")]
+        [Name("Poll"), Summary("Creates a poll with specified question and choices. Make sure to write the parameters between \"quotation marks\"")]
         public async Task Poll(string question, [Name("choice 1")] string choice1, [Name("choice 2")] string choice2)
             => await UtilitiesService.CreatePollAsync(question, choice1, choice2, Context);
 

--- a/CobraBot/Services/Moderation/ModerationService.cs
+++ b/CobraBot/Services/Moderation/ModerationService.cs
@@ -127,7 +127,7 @@ namespace CobraBot.Services.Moderation
 
             //Check if there is a valid role and give that role to the user
             if (guildSettings.RoleOnJoin != null && Helper.DoesRoleExist(user.Guild, guildSettings.RoleOnJoin) is var role && role != null)
-                await user.AddRoleAsync(role, new RequestOptions {AuditLogReason = "Auto role on join"});
+                await user.AddRoleAsync(role, new RequestOptions { AuditLogReason = "Auto role on join" });
 
             //Announce to WelcomeChannel that the user joined the server
             if (guildSettings.WelcomeChannel != 0)


### PR DESCRIPTION
# Extension methods
- Added extension method to check if user has permission to execute specified command as CheckPermissionsAsync conflicts with Ratelimit, thus ratelimiting users without them actually using the command

# Command handler
- Context is now created only if all checks pass
- Users can now @mention the bot to use commands
- Bot will no longer reply to Unknown commands

# Info module
- Changed command information command to chelp, as help was conflicting with the other help command