### PR TITLE
Implement private chat

### DIFF
--- a/CobraBot/CobraBot.csproj
+++ b/CobraBot/CobraBot.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
     <Authors>Telmo Duarte</Authors>
-    <Version>6.9</Version>
+    <Version>6.10</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -26,10 +26,6 @@
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0-dev-00839" />
     <PackageReference Include="System.IO" Version="4.3.0" />
     <PackageReference Include="Victoria" Version="5.1.11" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Migrations\" />
   </ItemGroup>
 
 </Project>

--- a/CobraBot/Database/BotContext.cs
+++ b/CobraBot/Database/BotContext.cs
@@ -32,11 +32,13 @@ namespace CobraBot.Database
 
         public DbSet<Guild> Guilds { get; set; }
         public DbSet<ModCase> ModCases { get; set; }
+        public DbSet<PrivateChat> PrivateChats { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             modelBuilder.Entity<Guild>().ToTable("Guilds");
             modelBuilder.Entity<ModCase>().ToTable("ModCases");
+            modelBuilder.Entity<PrivateChat>().ToTable("PrivateChats");
 
             // SQLite does not support DateTimeOffset
             foreach (var property in modelBuilder.Model.GetEntityTypes()

--- a/CobraBot/Database/Models/Guild.cs
+++ b/CobraBot/Database/Models/Guild.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
     Multi-purpose Discord Bot named Cobra
     Copyright (C) 2021 Telmo Duarte <contact@telmoduarte.me>
 
@@ -30,5 +30,6 @@ namespace CobraBot.Database.Models
         public ulong ModerationChannel { get; set; }
         public string CustomPrefix { get; set; }
         public string RoleOnJoin { get; set; }
+        public bool IsPrivateChatEnabled { get; set; }
     }
 }

--- a/CobraBot/Database/Models/PrivateChat.cs
+++ b/CobraBot/Database/Models/PrivateChat.cs
@@ -16,27 +16,24 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>. 
 */
 
-using Discord;
-using System.Threading.Tasks;
-using Serilog;
-using Victoria;
+using System.ComponentModel.DataAnnotations;
 
-namespace CobraBot.Services
+namespace CobraBot.Database.Models
 {
-    public sealed class LoggingService
+    public class PrivateChat
     {
-        public LoggingService(LavaNode lavaNode)
+        public PrivateChat(ulong userId, ulong channelId, ulong guildId)
         {
-            //These tree already have log messages
-            lavaNode.OnLog += LogAsync;
+            UserId = userId;
+            ChannelId = channelId;
+            GuildId = guildId;
         }
 
-        /// <summary> Method for logging messages to the console. </summary>
-        public static Task LogAsync(LogMessage message)
-        {
-            Log.Logger.Information(message.ToString());
+        [Key]
+        public int Id { get; set; }
 
-            return Task.CompletedTask;
-        }
+        public ulong UserId { get; set; }
+        public ulong ChannelId { get; set; }
+        public ulong GuildId { get; set; }
     }
 }

--- a/CobraBot/Modules/PrivateChatModule.cs
+++ b/CobraBot/Modules/PrivateChatModule.cs
@@ -1,0 +1,49 @@
+﻿/*
+    Multi-purpose Discord Bot named Cobra
+    Copyright (C) 2021 Telmo Duarte <contact@telmoduarte.me>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>. 
+*/
+
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using CobraBot.Preconditions;
+using CobraBot.Services;
+using CobraBot.Services.PrivateChat;
+using Discord;
+using Discord.Commands;
+
+namespace CobraBot.Modules
+{
+    [RequireContext(ContextType.Guild)]
+    [Name("Private Chat"), RequirePrivateChat]
+    public class PrivateChatModule : ModuleBase<SocketCommandContext>
+    {
+        public PrivateChatService PrivateChatService { get; set; }
+
+        //Command for creating private channels
+        [Command("pc create"), Alias("pcc"), 
+         Summary("Creates a private voice channel. If you don't specify allowed users, the channel will be public." +
+                 "\nTo specify allowed users, just mention them (example: @Cobra pc create @User1 @User2 @User3)" +
+                 "\nYou can change channel permissions anytime through Discord's Edit Channel screen.")]
+        public async Task CreateChannel([Name("allowed users")][Optional]params IUser[] allowedUsers)
+            => await PrivateChatService.CreateChannelAsync(Context, allowedUsers);
+        
+
+        //Command for deleting private channels
+        [Command("pc delete"), Alias("pcd"), Summary("Deletes your active private channel")]
+        public async Task DeleteChannel()
+            => await PrivateChatService.DeleteChannelAsync(Context);
+    }
+}

--- a/CobraBot/Modules/SetupModule.cs
+++ b/CobraBot/Modules/SetupModule.cs
@@ -64,6 +64,14 @@ namespace CobraBot.Modules
         [Name("Reset role on join"), Summary("Resets role that users receive when they join the server.")]
         public async Task ResetRoleOnJoin()
             => await ReplyAsync(embed: await SetupService.ResetRoleOnJoin(Context));
+
+
+        //Reset role on join
+        [Command("pc toggle")]
+        [Name("Toggle private chat"), Summary("Enables/disables private chat. (WIP feature)")]
+        public async Task TogglePc()
+            => await SetupService.EnablePrivateChatAsync(Context);
+
         #endregion
     }
 }

--- a/CobraBot/Preconditions/RequirePrivateChat.cs
+++ b/CobraBot/Preconditions/RequirePrivateChat.cs
@@ -1,0 +1,46 @@
+﻿/*
+    Multi-purpose Discord Bot named Cobra
+    Copyright (C) 2021 Telmo Duarte <contact@telmoduarte.me>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>. 
+*/
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using CobraBot.Database;
+using Discord.Commands;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CobraBot.Preconditions
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, Inherited = false)]
+    public class RequirePrivateChat : PreconditionAttribute
+    {
+        public override Task<PreconditionResult> CheckPermissionsAsync(ICommandContext context, CommandInfo command, IServiceProvider services)
+        {
+            var botContext = services.GetRequiredService<BotContext>();
+
+            var guildSettings = botContext.Guilds.AsNoTracking().FirstOrDefault(x => x.GuildId == context.Guild.Id);
+
+            if (guildSettings is null)
+                return Task.FromResult(PreconditionResult.FromError("Private chat is not enabled on this guild!"));
+
+            var isPrivateChatEnabled = guildSettings.IsPrivateChatEnabled;
+
+            return Task.FromResult(!isPrivateChatEnabled ? PreconditionResult.FromError("Private chat is not enabled on this guild!") : PreconditionResult.FromSuccess());
+        }
+    }
+}

--- a/CobraBot/Program.cs
+++ b/CobraBot/Program.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
     Multi-purpose Discord Bot named Cobra
     Copyright (C) 2021 Telmo Duarte <contact@telmoduarte.me>
 
@@ -27,6 +27,7 @@ using Victoria;
 using Discord.Commands;
 using CobraBot.Handlers;
 using CobraBot.Services.Moderation;
+using CobraBot.Services.PrivateChat;
 using Discord.Addons.Hosting;
 using EFCoreSecondLevelCacheInterceptor;
 using Interactivity;
@@ -115,14 +116,16 @@ namespace CobraBot
                             options
                                 .DisableLogging(true)
                                 .UseMemoryCacheProvider()
-                                .CacheAllQueries(CacheExpirationMode.Sliding, TimeSpan.FromHours(24));
+                                .CacheAllQueries(CacheExpirationMode.Sliding, TimeSpan.FromHours(12));
                         })
-                        .AddDbContextPool<BotContext>((serviceProvider, options) =>
+                        .AddDbContext<BotContext>((serviceProvider, options) =>
                         {
                             options.UseSqlite("Data Source=CobraDB.db");
                             options.AddInterceptors(serviceProvider.GetRequiredService<SecondLevelCacheInterceptor>());
-                        })
+                        }, ServiceLifetime.Transient)
                         .AddSingleton<InteractivityService>()
+                        .AddSingleton<PrivateChatService>()
+                        .AddHostedService<PrivateChatCleanup>()
                         .AddSingleton<MusicService>()
                         .AddSingleton<ModerationService>()
                         .AddSingleton<LookupService>()

--- a/CobraBot/Services/ApiService.cs
+++ b/CobraBot/Services/ApiService.cs
@@ -29,6 +29,7 @@ using System;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace CobraBot.Services
@@ -122,7 +123,7 @@ namespace CobraBot.Services
                     Color.DarkMagenta);
 
                 //Saves response to cache for 15 days
-                _memoryCache.Set($"DICTIONARY{wordToSearch}", embed, TimeSpan.FromDays(15));
+                _memoryCache.Set($"DICTIONARY{wordToSearch}", embed, Timeout.InfiniteTimeSpan);
 
                 return embed;
             }

--- a/CobraBot/Services/Moderation/LookupService.cs
+++ b/CobraBot/Services/Moderation/LookupService.cs
@@ -1,4 +1,23 @@
-﻿using CobraBot.Common.EmbedFormats;
+﻿#region License
+/*CitizenEnforcer - Moderation and logging bot
+Copyright(C) 2018-2020 Hawx
+https://github.com/Hawxy/CitizenEnforcer
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.If not, see http://www.gnu.org/licenses/ */
+#endregion
+
+using CobraBot.Common.EmbedFormats;
 using CobraBot.Database;
 using Discord.Commands;
 using Microsoft.EntityFrameworkCore;
@@ -37,5 +56,12 @@ namespace CobraBot.Services.Moderation
             //Send the mod case
             await context.Channel.SendMessageAsync(embed: ModerationFormats.LookupEmbed(modCase, username, modUsername));
         }
+
+
+
+        //public async Task LookupUserAsync(SocketCommandContext context, ulong userId)
+        //{
+
+        //}
     }
 }

--- a/CobraBot/Services/MusicService.cs
+++ b/CobraBot/Services/MusicService.cs
@@ -706,7 +706,7 @@ namespace CobraBot.Services
         /// </summary>
         public async Task<Embed> FetchLyricsAsync(IGuild guild)
         {
-            var player = _lavaNode.GetPlayer(guild);
+            _lavaNode.TryGetPlayer(guild, out var player);
 
             if (player?.Track == null)
                 return CustomFormats.CreateErrorEmbed("No music playing.");

--- a/CobraBot/Services/PrivateChat/PrivateChatCleanup.cs
+++ b/CobraBot/Services/PrivateChat/PrivateChatCleanup.cs
@@ -1,0 +1,96 @@
+﻿/*
+    Multi-purpose Discord Bot named Cobra
+    Copyright (C) 2021 Telmo Duarte <contact@telmoduarte.me>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>. 
+*/
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CobraBot.Database;
+using Discord;
+using Discord.WebSocket;
+using Microsoft.Extensions.Hosting;
+using Serilog;
+
+namespace CobraBot.Services.PrivateChat
+{
+    public class PrivateChatCleanup : IHostedService
+    {
+        private readonly BotContext _botContext;
+        private readonly DiscordSocketClient _client;
+        private Timer _timer;
+
+        public PrivateChatCleanup(BotContext botContext, DiscordSocketClient client)
+        {
+            _botContext = botContext;
+            _client = client;
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            _timer = new Timer(async _ => await CleanupPrivateChannels(), null, TimeSpan.FromSeconds(10), TimeSpan.FromMinutes(10));
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            _timer.Change(Timeout.InfiniteTimeSpan, TimeSpan.Zero);
+            return Task.CompletedTask;
+        }
+
+        /// <summary> Method called every 10 minutes to delete unused private channels. </summary>
+        private async Task CleanupPrivateChannels()
+        {
+            Log.Logger.Information("Started private channel cleanup.");
+
+            var deletedChannels = 0;
+
+            var privateChats = await _botContext.PrivateChats.AsAsyncEnumerable().ToListAsync();
+
+            //Loop through every private chat
+            foreach (var privateChat in privateChats)
+            {
+                //Get the guild for that private chat
+                var guild = _client.GetGuild(privateChat.GuildId);
+                var channel = guild.GetVoiceChannel(privateChat.ChannelId);
+
+                //If the channel isn't on the guild anymore, then delete the database entry
+                if (channel == null)
+                {
+                    _botContext.Remove(privateChat);
+                    await _botContext.SaveChangesAsync();
+                    continue;
+                }
+
+                //Count every user in the channel (except bots)
+                var channelUserCount = channel.Users.Count(u => !u.IsBot);
+
+                //If there is one or more users in the channel, continue
+                if (channelUserCount >= 1) continue;
+
+                //If there is less than 1 user in the channel, then delete the channel and delete the entry from the db
+                await channel.DeleteAsync(new RequestOptions {AuditLogReason = "Delete private channel as it is empty"});
+                deletedChannels++;
+
+                _botContext.Remove(privateChat);
+                await _botContext.SaveChangesAsync();
+            }
+
+            Log.Logger.Information($"Private channels cleanup deleted {deletedChannels} channels.");
+        }
+    }
+}

--- a/CobraBot/Services/PrivateChat/PrivateChatService.cs
+++ b/CobraBot/Services/PrivateChat/PrivateChatService.cs
@@ -1,0 +1,209 @@
+﻿/*
+    Multi-purpose Discord Bot named Cobra
+    Copyright (C) 2021 Telmo Duarte <contact@telmoduarte.me>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>. 
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using CobraBot.Common.EmbedFormats;
+using CobraBot.Database;
+using Discord;
+using Discord.Commands;
+using Discord.Rest;
+using Discord.WebSocket;
+using Microsoft.EntityFrameworkCore;
+
+namespace CobraBot.Services.PrivateChat
+{
+    public sealed class PrivateChatService
+    {
+        private readonly BotContext _botContext;
+        private readonly DiscordSocketClient _client;
+
+        public PrivateChatService(DiscordSocketClient client, BotContext botContext)
+        {
+            _botContext = botContext;
+            _client = client;
+
+            client.UserVoiceStateUpdated += UserVoiceStateUpdated;
+        }
+
+
+        /// <summary>Fired whenever someone joins/leaves a voice channel.
+        /// <para>Automatically deletes the private voice channel if the channel has no users in it.</para>
+        /// </summary>
+        private async Task UserVoiceStateUpdated(SocketUser user, SocketVoiceState oldState, SocketVoiceState newState)
+        {
+            if (user.IsBot)
+                return;
+
+            if (oldState.VoiceChannel == null)
+                return;
+
+            if (oldState.VoiceChannel == newState.VoiceChannel)
+                return;
+
+            //Check if the channel is on the private chat database
+            var privateChat =  await _botContext.PrivateChats.AsQueryable().FirstOrDefaultAsync(x => x.ChannelId == oldState.VoiceChannel.Id);
+
+            if (privateChat == null)
+                return;
+
+            //OldState voice channel is the channel id we want
+            var channelId = privateChat.ChannelId;
+
+            //We check if the old voice state
+            if (!(newState.VoiceChannel?.Id != channelId || newState.VoiceChannel == null))
+                return;
+
+            //We count every user in the channel that isn't a bot, and put that result in 'users' variable
+            int users = oldState.VoiceChannel.Users.Count(u => !u.IsBot);
+
+            //If there are no users left in the voice channel, we make the bot leave
+            if (users < 1)
+            {
+                var guild = await _client.Rest.GetGuildAsync(privateChat.GuildId);
+                
+                var channelToDelete = await guild.GetVoiceChannelAsync(channelId);
+
+                if (channelToDelete == null)
+                    return;
+
+                await channelToDelete.DeleteAsync(new RequestOptions { AuditLogReason = "Delete private channel as it is empty" });
+
+                _botContext.PrivateChats.Remove(privateChat);
+                await _botContext.SaveChangesAsync();
+            }
+        }
+
+        /// <summary> Method for creating a new voice channel. </summary>
+        /// <param name="context"> The command context. </param>
+        /// <param name="allowedUsers"> The users allowed to join the channel. If null, the channel will be public. </param>
+        public async Task CreateChannelAsync(SocketCommandContext context, IUser[] allowedUsers)
+        {
+            if (context.User is not IGuildUser user)
+                return;
+
+            //Check if the user is in a voice channel when he casts the comand
+            if (user.VoiceChannel is null)
+            {
+                await context.Channel.SendMessageAsync(
+                    embed: CustomFormats.CreateErrorEmbed("You must be in a voice channel first!"));
+                return;
+            }
+
+            var privateChat = await _botContext.PrivateChats.AsQueryable().AsNoTracking().FirstOrDefaultAsync(x => x.UserId == context.User.Id);
+
+            //Check if the user already has an active voice channel
+            if (privateChat != null)
+            {
+                await context.Channel.SendMessageAsync(embed: CustomFormats.CreateErrorEmbed("You already have an active channel!\nUse the `pc delete` command to delete it."));
+                return;
+            }
+
+            //List of overwrite permissions
+            var permissionsList = new List<Overwrite>
+            {
+                //We add the channel owner permissions
+                new(context.User.Id, PermissionTarget.User, new OverwritePermissions(
+                    viewChannel: PermValue.Allow, 
+                    connect: PermValue.Allow, 
+                    useVoiceActivation: PermValue.Allow,
+                    muteMembers: PermValue.Allow,
+                    manageChannel: PermValue.Allow, 
+                    manageRoles: PermValue.Allow)),
+            };
+
+            if (allowedUsers != null)
+            {
+                //Add connect, view and voice activation permissions to every allowed user
+                foreach (var allowedUser in allowedUsers)
+                {
+                    permissionsList.Add(new Overwrite(allowedUser.Id, PermissionTarget.User, new OverwritePermissions(
+                        viewChannel: PermValue.Allow, 
+                        connect: PermValue.Allow, 
+                        useVoiceActivation: PermValue.Allow)));
+                }
+
+                //Deny permission for everyone except the allowed users
+                permissionsList.Add(new Overwrite(context.Guild.EveryoneRole.Id, PermissionTarget.Role,
+                    new OverwritePermissions(viewChannel: PermValue.Deny)));
+            }
+            else
+            {
+                //If no allowed users are passed, then the channel is created as public
+                permissionsList.Add(new Overwrite(context.Guild.EveryoneRole.Id, PermissionTarget.Role, new OverwritePermissions(viewChannel: PermValue.Allow, connect: PermValue.Allow)));
+            }
+
+            RestVoiceChannel createdChannel;
+
+            try
+            {
+                //Create the channel with specified permissions
+                createdChannel = await context.Guild.CreateVoiceChannelAsync($"{context.User.Username}'s chat",
+                    x =>
+                    {
+                        x.PermissionOverwrites = permissionsList;
+                    },
+                    new RequestOptions {AuditLogReason = "Create private chat"});
+            }
+            catch (Exception)
+            {
+                await context.Channel.SendMessageAsync(
+                    embed: CustomFormats.CreateErrorEmbed("There has been an error"));
+                return;
+            }
+
+
+            //Add private channel to the database
+            await _botContext.PrivateChats.AddAsync(new Database.Models.PrivateChat(context.User.Id, createdChannel.Id, context.Guild.Id));
+            await _botContext.SaveChangesAsync();
+
+            await user.ModifyAsync(x => x.Channel = createdChannel);
+
+            await context.Message.AddReactionAsync(new Emoji("👍"));
+        }
+
+
+        /// <summary> Method for deleting the command's invoker private channel. </summary>
+        /// <param name="context"> The command context. </param>
+        public async Task DeleteChannelAsync(SocketCommandContext context)
+        {
+            var privateChat = await _botContext.PrivateChats.AsQueryable().FirstOrDefaultAsync(x => x.UserId == context.User.Id);
+            
+            //Check if the user already has an active voice channel
+            if (privateChat == null)
+            {
+                await context.Channel.SendMessageAsync(embed: CustomFormats.CreateErrorEmbed("You don't have an active channel!"));
+                return;
+            }
+
+            var channelToDelete = context.Guild.GetVoiceChannel(privateChat.ChannelId);
+            if (channelToDelete != null)
+            {
+                await channelToDelete.DeleteAsync(new RequestOptions
+                    {AuditLogReason = "User deleted his private channel"});
+            }
+
+            _botContext.PrivateChats.Remove(privateChat);
+            await _botContext.SaveChangesAsync();
+                
+            await context.Message.AddReactionAsync(new Emoji("👍"));
+        }
+    }
+}


### PR DESCRIPTION
# Private Chat
- Added private chat functionality, it enables users to create their own private/public voice channels
- PrivateChatCleanup class has a timer that calls a cleanup method every 10 minutes

# Database
- Added PrivateChats so the bot can keep track of every private chat and remove them when no one is on the channel anymore
- Added IsPrivateChatEnabled to Guild settings

# Preconditions
- Added RequirePrivateChat precondition. This way, the command is only run if the guild has private chat enabled